### PR TITLE
Increased MAX_OUTBOUND_CONNECTIONS to 16

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -27,7 +27,7 @@
 using namespace std;
 using namespace boost;
 
-static const int MAX_OUTBOUND_CONNECTIONS = 8;
+static const int MAX_OUTBOUND_CONNECTIONS = 16;
 
 bool OpenNetworkConnection(const CAddress& addrConnect, CSemaphoreGrant *grantOutbound = NULL, const char *strDest = NULL, bool fOneShot = false);
 


### PR DESCRIPTION
Increased outbound connects max to 16 for better peering of network. This is similar to how blockchain.info and others get a high connection count. Many Pool servers use this type of code to ensure rapid distribution of their blocks.

This also allows better broadcast of transactions to network peers resulting in fewer "stuck" transactions as have been reported at times.
