### PR TITLE
Remove calls to GetPresentValue and GetTimeAdjustedValue where relative depth is always zero

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2302,7 +2302,7 @@ bool CBlock::ConnectBlock(CValidationState &state, CBlockIndex* pindex, CCoinsVi
     if (vtx[0].nRefHeight != pindex->nHeight)
         return state.DoS(100, error("ConnectBlock() : coinbase height != block height"));
 
-    mpq qActualCoinbaseValue = GetTimeAdjustedValue(vtx[0].GetValueOut(), pindex->nHeight - vtx[0].nRefHeight);
+    mpq qActualCoinbaseValue = vtx[0].GetValueOut();
     mpq qAllowedCoinbaseValue = GetBlockValue(pindex->nHeight, nFees);
     if ( qActualCoinbaseValue > qAllowedCoinbaseValue )
         return state.DoS(100, error("ConnectBlock() : coinbase pays too much (actual=%s vs limit=%s)", FormatMoney(qActualCoinbaseValue).c_str(), FormatMoney(qAllowedCoinbaseValue).c_str()));

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -174,7 +174,7 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx)
                         }
                     }
 
-                    strHTML += "<b>" + tr("Debit") + ":</b> " + BitcoinUnits::formatWithUnit(BitcoinUnits::BTC, -GetPresentValue(wtx, txout, wtx.nRefHeight)) + "<br>";
+                    strHTML += "<b>" + tr("Debit") + ":</b> " + BitcoinUnits::formatWithUnit(BitcoinUnits::BTC, -i64_to_mpq(txout.nValue)) + "<br>";
                 }
 
                 if (fAllToMe)

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -43,7 +43,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                 TransactionRecord sub(hash, nTime);
                 CTxDestination address;
                 sub.idx = parts.size(); // sequence number
-                sub.credit = GetPresentValue(wtx, txout, wtx.nRefHeight);
+                sub.credit = i64_to_mpq(txout.nValue);
                 if (ExtractDestination(txout.scriptPubKey, address) && IsMine(*wallet, address))
                 {
                     // Received by Bitcoin Address
@@ -122,7 +122,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                     sub.address = mapValue["to"];
                 }
 
-                mpq nValue = GetPresentValue(wtx, txout, wtx.nRefHeight);
+                mpq nValue = i64_to_mpq(txout.nValue);
                 /* Add fee to first output */
                 if (nTxFee > 0)
                 {

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -146,7 +146,7 @@ bool CCoinsViewDB::GetStats(CCoinsStats &stats) {
                         stats.nTransactionOutputs++;
                         ss << VARINT(i+1);
                         ss << out;
-                        nTotalAmount += GetPresentValue(coins, out, coins.nHeight);
+                        nTotalAmount += i64_to_mpq(out.nValue);
                     }
                 }
                 stats.nSerializedSize += 32 + slValue.size();

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -722,7 +722,7 @@ public:
 
     std::string ToString() const
     {
-        return strprintf("COutput(%s, %d, %d) [%s]", tx->GetHash().ToString().c_str(), i, nDepth, FormatMoney(GetPresentValue(*tx, tx->vout[i], 0)).c_str());
+        return strprintf("COutput(%s, %d, %d) [%s]", tx->GetHash().ToString().c_str(), i, nDepth, FormatMoney(i64_to_mpq(tx->vout[i].nValue)).c_str());
     }
 
     void print() const


### PR DESCRIPTION
These calls don't actually do anything, because the depth argument is zero.