### PR TITLE
[RPC] Change 'listreceived' behavior to show output value / sum totals calculated at time of receipt rather than at the present block height

### DIFF
--- a/contrib/debian/changelog
+++ b/contrib/debian/changelog
@@ -1,3 +1,8 @@
+  [Mark Friedenbach]
+    * Change behavior of the '{get,list}receivedby{address,account}'
+      RPCs to show output value / sum totals calculated at refheight
+      rather than at the present block height.
+
 freicoin (0.8.6~precise1) precise; urgency=high
 
   [Mark Friedenbach]

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -384,6 +384,13 @@ Value verifymessage(const Array& params, bool fHelp)
 }
 
 
+mpq GetReceivedValue(const CWalletTx &wtx, const CTxOut &txout)
+{
+    CBlockIndex *pBlockIndex;
+    int nBlockDepth = wtx.GetDepthInMainChain(pBlockIndex);
+    return GetPresentValue(wtx, txout, nBestHeight + 1 - nBlockDepth - wtx.nRefHeight);
+}
+
 Value getreceivedbyaddress(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() < 1 || params.size() > 2)
@@ -416,7 +423,7 @@ Value getreceivedbyaddress(const Array& params, bool fHelp)
         BOOST_FOREACH(const CTxOut& txout, wtx.vout)
             if (txout.scriptPubKey == scriptPubKey)
                 if (wtx.GetDepthInMainChain() >= nMinDepth)
-                    nAmount += GetPresentValue(wtx, txout, nBestHeight);
+                    nAmount += GetReceivedValue(wtx, txout);
     }
 
     return  ValueFromAmount(nAmount);
@@ -464,7 +471,7 @@ Value getreceivedbyaccount(const Array& params, bool fHelp)
             CTxDestination address;
             if (ExtractDestination(txout.scriptPubKey, address) && IsMine(*pwalletMain, address) && setAddress.count(address))
                 if (wtx.GetDepthInMainChain() >= nMinDepth)
-                    nAmount += GetPresentValue(wtx, txout, nBestHeight);
+                    nAmount += GetReceivedValue(wtx, txout);
         }
     }
 
@@ -861,7 +868,7 @@ Value ListReceived(const Array& params, bool fByAccounts)
                 continue;
 
             tallyitem& item = mapTally[address];
-            item.nAmount += GetPresentValue(wtx, txout, nBestHeight);
+            item.nAmount += GetReceivedValue(wtx, txout);
             item.nConf = min(item.nConf, nDepth);
         }
     }


### PR DESCRIPTION
This is a work-in-progress, posted here for evaluation of the idea itself before work progresses further. During a rebase I noticed that the 'getreceivedbyaddress', 'getreceivedbyaccount', 'listreceivedbyaddress' and 'listreceivedbyaccount' show the CURRENT value received at an address or account, not the value at the time it was received.

I'm not really sure why we do the present behavior. I can't think of a single use case where you'd want to know the current value, as opposed to the value at the time it was sent. And indeed, I could see this being a source of bugs where either payments are under-reported, or credits applied incorrectly.

This patch takes the first steps towards correcting this by showing the value at the time it was seen on the block chain (or the next block if it is unconfirmed). A better patch would track the block height at the time it was first seen (with special care for things seen during IBD) and use that value, if any.