### PR TITLE
[Soft-fork] Enable BIP8-like activation of the new truncation rules supporting integer-math-only demurrage calculations

### DIFF
--- a/contrib/debian/changelog
+++ b/contrib/debian/changelog
@@ -2,6 +2,11 @@
     * Change behavior of the '{get,list}receivedby{address,account}'
       RPCs to show output value / sum totals calculated at refheight
       rather than at the present block height.
+    * Add soft-fork to switch demurrage calculation logic to an integer math
+      implementation, which sometimes differs from an exact calculation by as
+      much as 1 kria. This results in an order of magnitude increase in speed
+      of calculation, and allows for the future removal of the GMP and MPFR
+      library dependencies.
 
 freicoin (0.8.6~precise1) precise; urgency=high
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1835,6 +1835,155 @@ const CTxOut &CTransaction::GetOutputFor(const CTxIn& input, CCoinsViewCache& vi
     return coins.vout[input.prevout.n];
 }
 
+static int64_t GetTimeAdjustedValue_apu_inner(int64_t value, unsigned relative_depth)
+{
+    /* This array of pre-generated constants is an exponentiation
+     * ladder of properly calculated 64-bit fixed point demurrage
+     * rates for power-of-2 block intervals. Calculating the actual
+     * demurrage rate for the passed in relative_depth is a matter of
+     * performing fixed point multiplication of the factors
+     * corresponding to the powers of 2 (set bits) which make up
+     * relative_depth.
+     *
+     * Our lookup table does not go beyond 26 entries because a
+     * relative_depth of 1<<26 (the would-be 27th entry) would cause
+     * even MAX_MONEY (2^53 - 1) to decay to zero. */
+    static std::array<uint32_t, 2*26> k32 = {
+        0xfffff000UL, 0x00000000UL, /* 2^0 = 1 */
+        0xffffe000UL, 0x01000000UL, /* 2^1 = 2 */
+        0xffffc000UL, 0x05ffffc0UL, /* 2^2 = 4 */
+        0xffff8000UL, 0x1bfffc80UL, /* 2^3 = 8 */
+        0xffff0000UL, 0x77ffdd00UL, /* ... */
+        0xfffe0001UL, 0xeffeca00UL,
+        0xfffc0007UL, 0xdff5d409UL,
+        0xfff8001fUL, 0xbfaca8a2UL,
+        0xfff0007fUL, 0x7d5d5a6aUL,
+        0xffe001feUL, 0xeacb48a8UL,
+        0xffc007fdUL, 0x55dfda2aUL,
+        0xff801ff6UL, 0xad5499cdUL,
+        0xff007fcdUL, 0x67f98aadUL,
+        0xfe01fe9bUL, 0x74f0943eUL,
+        0xfc07f540UL, 0x767d2a82UL,
+        0xf81fab16UL, 0x3dc15990UL,
+        0xf07d5f65UL, 0xf9604ac9UL,
+        0xe1eb5045UL, 0x80b6ebf7UL,
+        0xc75f7b66UL, 0xa5075defUL,
+        0x9b459576UL, 0x663bbb3eUL,
+        0x5e2d55e7UL, 0x48e27ab4UL,
+        0x22a5531dUL, 0x29a95916UL,
+        0x04b054d7UL, 0xfda49c4dUL,
+        0x0015fc1bUL, 0x85085be9UL,
+        0x000001e3UL, 0x54ca043cUL,
+        0x00000000UL, 0x00039089UL };
+
+    /* The demurrage rate for a depth of 0, which is 1.0 exactly, has
+     * no representation in 0.64 fixed point. */
+    if (relative_depth == 0)
+        return value;
+    /* Depth of (1<<26) and beyond are sufficient to decay even
+     * MAX_MONEY to zero. */
+    if (relative_depth >= (1<<26))
+        return 0;
+
+    /* Overflow sensitive fixed point multiply-and-accumulate methods
+     * which are used both for the exponentiation to calcuate the
+     * demurrage rate, and the final multiply at the end. */
+    uint64_t sum, overflow;
+    auto shift32 = [&]() {
+        sum = (overflow << 32) + (sum >> 32);
+        overflow = 0;
+    };
+    auto term = [&](uint64_t val) {
+        overflow += (sum + val) < sum;
+        sum += val;
+    };
+
+    /* We calculate the first 64 fractional bits of the demurrage rate
+     * for relative_depth by raising the per-block rate of (1 - 2^-20)
+     * to the relative_depth power. To perform this computation
+     * efficiently we perform N multiplications of a pre-computed
+     * exponentiation ladder, where N is the number of set bits in the
+     * binary representation of relative_depth. */
+
+    /* At the end of this calculation w will contain the first 64 bits
+     * of the demurrage rate as a pair of 32-bit unsigned words, the
+     * most significant word first. Its initial value is
+     * multiplicative identity, 1.0, for which the fractional bits are
+     * zero. */
+    std::array<uint32_t, 2> w = { };
+
+    /* The first multiplication has the accumulator set to 1.0, which
+     * is the only time it has a value >= 1. This means that there are
+     * some terms which are non-zero on only the very first
+     * multiplication performed, and since the fractional bits of 1.0
+     * are zero, the other terms that would normally are used are
+     * not. */
+    bool first = true;
+
+    for (int bit = 0; relative_depth; relative_depth >>= 1, ++bit) {
+        if (relative_depth & 1) {
+            /* Zero-extend the accumulator state and ladder entry as
+             * we will be doing our multiplications in 64-bit to
+             * capture to full range. */
+            const uint64_t w0 = w[0];
+            const uint64_t w1 = w[1];
+            const uint64_t k0 = k32[2*bit];
+            const uint64_t k1 = k32[2*bit+1];
+
+            /* Carry out the multiplication, term-by-term. Terms whose
+             * contribution to the final result are entirely wiped
+             * away by truncation are not included. */
+
+            sum = k1;
+            overflow = 0;
+            if (!first) {
+                sum *= w0;
+                term(k0 * w1);
+                shift32();
+                term(k0 * w0);
+            }
+            w[1] = static_cast<uint32_t>(sum);
+            shift32();
+
+            if (first) {
+                term(k0);
+            }
+            w[0] = static_cast<uint32_t>(sum);
+
+            /* Debugging check: under no circumstances should it ever
+             * be the case that the high-order bits of sum (including
+             * detected overflow) are non-zero. That would indicate
+             * that the multiplication resulted in a value of 1.0 or
+             * greater, which shouldn't be possile. */
+            // shift32();
+            // assert(sum == 0);
+
+            first = false;
+        }
+    }
+
+    /* We now perform an approximately similar multiplication of the
+     * final calculated demurrage factor by the passed in value. */
+    const uint64_t v0 = static_cast<uint32_t>(value);
+    const uint64_t v1 = value >> 32;
+
+    overflow = 0;
+    sum = (w[1] * v0) >> 32;
+    term(w[1] * v1);
+    term(w[0] * v0);
+    shift32();
+    term(w[0] * v1);
+
+    /* Debugging check: having the overflow bit set at this point
+     * would indicate that the demurrage calculation has resulted in
+     * an amount that is greater than std::numeric_limits<int64_t>::
+     * max(), which should never be possible as the demurrage factor
+     * should always be a fractional number less than one. */
+    // assert(overflow == 0);
+
+    return sum;
+}
+
 mpq GetTimeAdjustedValue(int64 nInitialValue, int nRelativeDepth)
 {
     return GetTimeAdjustedValue(i64_to_mpq(nInitialValue), nRelativeDepth);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1848,7 +1848,7 @@ static int64_t GetTimeAdjustedValue_apu_inner(int64_t value, unsigned relative_d
      * Our lookup table does not go beyond 26 entries because a
      * relative_depth of 1<<26 (the would-be 27th entry) would cause
      * even MAX_MONEY (2^53 - 1) to decay to zero. */
-    static std::array<uint32_t, 2*26> k32 = {
+    static const uint32_t k32[2*26] = {
         0xfffff000UL, 0x00000000UL, /* 2^0 = 1 */
         0xffffe000UL, 0x01000000UL, /* 2^1 = 2 */
         0xffffc000UL, 0x05ffffc0UL, /* 2^2 = 4 */
@@ -1889,14 +1889,15 @@ static int64_t GetTimeAdjustedValue_apu_inner(int64_t value, unsigned relative_d
      * which are used both for the exponentiation to calcuate the
      * demurrage rate, and the final multiply at the end. */
     uint64_t sum, overflow;
-    auto shift32 = [&]() {
-        sum = (overflow << 32) + (sum >> 32);
-        overflow = 0;
-    };
-    auto term = [&](uint64_t val) {
-        overflow += (sum + val) < sum;
-        sum += val;
-    };
+    #define shift32() do { \
+        sum = (overflow << 32) + (sum >> 32); \
+        overflow = 0; \
+    } while (0)
+    #define term(_val) do { \
+        const uint64_t val = (_val); \
+        overflow += (sum + val) < sum; \
+        sum += val; \
+    } while (0)
 
     /* We calculate the first 64 fractional bits of the demurrage rate
      * for relative_depth by raising the per-block rate of (1 - 2^-20)
@@ -1910,7 +1911,7 @@ static int64_t GetTimeAdjustedValue_apu_inner(int64_t value, unsigned relative_d
      * most significant word first. Its initial value is
      * multiplicative identity, 1.0, for which the fractional bits are
      * zero. */
-    std::array<uint32_t, 2> w = { };
+    uint32_t w[2] = { 0 };
 
     /* The first multiplication has the accumulator set to 1.0, which
      * is the only time it has a value >= 1. This means that there are

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -764,10 +764,10 @@ bool CTxMemPool::accept(CValidationState &state, CTransaction &tx, bool fCheckIn
         // right away as policy.
         const bool fTruncateInputs = true;
 
-        // APU demurrage calculation is a yet-to-be-scheduled
-        // soft-fork change to improve the performance of demurrage
-        // calculations.
-        const bool fUseAPU = false;
+        // APU demurrage calculation is a scheduled soft-fork change
+        // to improve the performance of demurrage calculations, but
+        // it is enabled immediately as policy.
+        const bool fUseAPU = true;
 
         // Note: if you modify this code to accept non-standard transactions, then
         // you should add code here to check that the transaction does a
@@ -5124,7 +5124,7 @@ CBlockTemplate* CreateNewBlock(CReserveKey& reservekey)
     // If set, fractional fees are not aggregated into the coinbase.
     const bool fTruncateInputs = true;
     // If set, APU arithmetic is used for demurrage calculations.
-    const bool fUseAPU = false;
+    const bool fUseAPU = true;
 
     // Largest block you're willing to create:
     unsigned int nBlockMaxSize = GetArg("-blockmaxsize", DEFAULT_BLOCK_MAX_SIZE);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2421,6 +2421,18 @@ bool CBlock::ConnectBlock(CValidationState &state, CBlockIndex* pindex, CCoinsVi
         fTruncateInputs = true;
     }
 
+    // Whether APU arithmetic should be used for demurrage
+    // calculations.
+    bool fUseAPU = false;
+
+    if ((pindex->nHeight >= APU_ACTIVATION_HEIGHT) ||
+        (((nVersion >> 28) == 3) &&
+         ((!fTestNet && CBlockIndex::IsSuperMajorityBit(28, pindex->pprev, 750, 1000)) ||
+          (fTestNet && CBlockIndex::IsSuperMajorityBit(28, pindex->pprev, 51, 100)))))
+    {
+        fUseAPU = true;
+    }
+
     CBlockUndo blockundo;
 
     CCheckQueueControl<CScriptCheck> control(fScriptChecks && nScriptCheckThreads ? &scriptcheckqueue : NULL);
@@ -3009,6 +3021,16 @@ bool CBlock::AcceptBlock(CValidationState &state, CDiskBlockPos *dbp)
                 return state.Invalid(error("AcceptBlock() : rejected nVersion=2 block"));
             }
         }
+        // Reject non-signaling blocks when 95% (75% on testnet) of
+        // the network has upgraded (until timeout activation):
+        if ((nHeight < APU_ACTIVATION_HEIGHT) && ((nVersion >> 28) != 3))
+        {
+            if ((!fTestNet && CBlockIndex::IsSuperMajorityBit(28, pindexPrev, 950, 1000)) ||
+                (fTestNet && CBlockIndex::IsSuperMajorityBit(28, pindexPrev, 75, 100)))
+            {
+                return state.Invalid(error("AcceptBlock() : rejected non-APU block before activation timeout"));
+            }
+        }
         // Enforce block.nVersion=2 rule that the coinbase starts with serialized block height
         if (nVersion >= 2)
         {
@@ -3060,6 +3082,18 @@ bool CBlockIndex::IsSuperMajority(int minVersion, const CBlockIndex* pstart, uns
     for (unsigned int i = 0; i < nToCheck && nFound < nRequired && pstart != NULL; i++)
     {
         if (pstart->nVersion >= minVersion)
+            ++nFound;
+        pstart = pstart->pprev;
+    }
+    return (nFound >= nRequired);
+}
+
+bool CBlockIndex::IsSuperMajorityBit(int bit, const CBlockIndex* pstart, unsigned int nRequired, unsigned int nToCheck)
+{
+    unsigned int nFound = 0;
+    for (unsigned int i = 0; i < nToCheck && nFound < nRequired && pstart != NULL; i++)
+    {
+        if (((pstart->nVersion >> 29) == 1) && (pstart->nVersion & (1 << bit)))
             ++nFound;
         pstart = pstart->pprev;
     }

--- a/src/main.h
+++ b/src/main.h
@@ -61,6 +61,7 @@ static const mpq TITHE_RATIO = mpq("4/5");
 static const mpq TITHE_AMOUNT = MPQ_MAX_MONEY * TITHE_RATIO / EQ_HEIGHT;
 static const mpq INITIAL_SUBSIDY = mpq("15916928404");
 static const int DEMURRAGE_RATE = 1048576;
+static const int APU_ACTIVATION_HEIGHT = 229376;
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
 static const int COINBASE_MATURITY = 100;
 /** Threshold for nLockTime: below this value it is interpreted as block number, otherwise as UNIX timestamp. */
@@ -1343,7 +1344,7 @@ class CBlockHeader
 {
 public:
     // header
-    static const int CURRENT_VERSION=3;
+    static const int CURRENT_VERSION=0x30000000;
     int nVersion;
     uint256 hashPrevBlock;
     uint256 hashMerkleRoot;
@@ -1859,6 +1860,8 @@ public:
      */
     static bool IsSuperMajority(int minVersion, const CBlockIndex* pstart,
                                 unsigned int nRequired, unsigned int nToCheck);
+    static bool IsSuperMajorityBit(int bit, const CBlockIndex* pstart,
+                                   unsigned int nRequired, unsigned int nToCheck);
 
     std::string ToString() const
     {

--- a/src/main.h
+++ b/src/main.h
@@ -189,12 +189,15 @@ std::string GetWarnings(std::string strFor);
 /** Retrieve a transaction (from memory pool, or from disk, if possible) */
 bool GetTransaction(const uint256 &hash, CTransaction &tx, uint256 &hashBlock, bool fAllowSlow = false);
 /** Calculating present value after subtracting demurrage */
-mpq GetTimeAdjustedValue(int64 nInitialValue, int nRelativeDepth);
-mpq GetTimeAdjustedValue(const mpz &zInitialValue, int nRelativeDepth);
-mpq GetTimeAdjustedValue(const mpq &qInitialValue, int nRelativeDepth);
+mpq GetTimeAdjustedValue_apu(int64 nInitialValue, int nRelativeDepth);
+mpq GetTimeAdjustedValue_apu(const mpz &zInitialValue, int nRelativeDepth);
+mpq GetTimeAdjustedValue_apu(const mpq &qInitialValue, int nRelativeDepth);
+mpq GetTimeAdjustedValue_mpfr(int64 nInitialValue, int nRelativeDepth);
+mpq GetTimeAdjustedValue_mpfr(const mpz &zInitialValue, int nRelativeDepth);
+mpq GetTimeAdjustedValue_mpfr(const mpq &qInitialValue, int nRelativeDepth);
 /** Calculate value of an output at the specified block height */
-mpq GetPresentValue(const CCoins& coins, const CTxOut& output, int nBlockHeight);
-mpq GetPresentValue(const CTransaction& tx, const CTxOut& output, int nBlockHeight);
+mpq GetPresentValue(const CCoins& coins, const CTxOut& output, int nBlockHeight, bool fUseAPU);
+mpq GetPresentValue(const CTransaction& tx, const CTxOut& output, int nBlockHeight, bool fUseAPU);
 /** Connect/disconnect blocks until pindexNew is the new tip of the active block chain */
 bool SetBestChain(CValidationState &state, CBlockIndex* pindexNew);
 /** Find the best known block, and make it the tip of the block chain */
@@ -651,9 +654,10 @@ public:
 
         @param[in] mapInputs		Map of previous transactions that have outputs we're spending
         @param[in] fTruncateInputs	If set, each input is truncated [floor()] to the nearest kria after present value adjustment, making the result an integer number of the smallest representable units.
+        @param[in] fUseAPU              If set, demurrage calculation is done using integer fixed point
         @return	Sum of value of all inputs (scriptSigs)
      */
-    mpq GetValueIn(CCoinsViewCache& mapInputs, bool fTruncateInputs) const;
+    mpq GetValueIn(CCoinsViewCache& mapInputs, bool fTruncateInputs, bool fUseAPU) const;
 
     static bool AllowFree(double dPriority)
     {
@@ -708,7 +712,7 @@ public:
     // Check whether all inputs of this transaction are valid (no double spends, scripts & sigs, amounts)
     // This does not modify the UTXO set. If pvChecks is not NULL, script checks are pushed onto it
     // instead of being performed inline.
-    bool CheckInputs(CValidationState &state, CCoinsViewCache &view, bool fTruncateInputs,
+    bool CheckInputs(CValidationState &state, CCoinsViewCache &view, bool fTruncateInputs, bool fUseAPU,
                      bool fScriptChecks = true,
                      unsigned int flags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC,
                      std::vector<CScriptCheck> *pvChecks = NULL) const;

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -260,7 +260,7 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx)
                                     strHTML += GUIUtil::HtmlEscape(wallet->mapAddressBook[address]) + " ";
                                 strHTML += QString::fromStdString(CBitcoinAddress(address).ToString());
                             }
-                            strHTML = strHTML + " " + tr("Amount") + "=" + BitcoinUnits::formatWithUnit(BitcoinUnits::BTC, GetPresentValue(wtx, vout, wtx.nRefHeight, false));
+                            strHTML = strHTML + " " + tr("Amount") + "=" + BitcoinUnits::formatWithUnit(BitcoinUnits::BTC, GetPresentValue(wtx, vout, wtx.nRefHeight, true));
                             strHTML = strHTML + " IsMine=" + (wallet->IsMine(vout) ? tr("true") : tr("false")) + "</li>";
                         }
                     }

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -260,7 +260,7 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx)
                                     strHTML += GUIUtil::HtmlEscape(wallet->mapAddressBook[address]) + " ";
                                 strHTML += QString::fromStdString(CBitcoinAddress(address).ToString());
                             }
-                            strHTML = strHTML + " " + tr("Amount") + "=" + BitcoinUnits::formatWithUnit(BitcoinUnits::BTC, GetPresentValue(wtx, vout, wtx.nRefHeight));
+                            strHTML = strHTML + " " + tr("Amount") + "=" + BitcoinUnits::formatWithUnit(BitcoinUnits::BTC, GetPresentValue(wtx, vout, wtx.nRefHeight, false));
                             strHTML = strHTML + " IsMine=" + (wallet->IsMine(vout) ? tr("true") : tr("false")) + "</li>";
                         }
                     }

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -216,7 +216,7 @@ Value gettxout(const Array& params, bool fHelp)
         ret.push_back(Pair("confirmations", 0));
     else
         ret.push_back(Pair("confirmations", pcoinsTip->GetBestBlock()->nHeight - coins.nHeight + 1));
-    ret.push_back(Pair("value", ValueFromAmount(GetPresentValue(coins, coins.vout[n], nBlockHeight))));
+    ret.push_back(Pair("value", ValueFromAmount(GetPresentValue(coins, coins.vout[n], nBlockHeight, false))));
     Object o;
     ScriptPubKeyToJSON(coins.vout[n].scriptPubKey, o);
     ret.push_back(Pair("scriptPubKey", o));

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -216,7 +216,7 @@ Value gettxout(const Array& params, bool fHelp)
         ret.push_back(Pair("confirmations", 0));
     else
         ret.push_back(Pair("confirmations", pcoinsTip->GetBestBlock()->nHeight - coins.nHeight + 1));
-    ret.push_back(Pair("value", ValueFromAmount(GetPresentValue(coins, coins.vout[n], nBlockHeight, false))));
+    ret.push_back(Pair("value", ValueFromAmount(GetPresentValue(coins, coins.vout[n], nBlockHeight, true))));
     Object o;
     ScriptPubKeyToJSON(coins.vout[n].scriptPubKey, o);
     ret.push_back(Pair("scriptPubKey", o));

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -221,7 +221,7 @@ Value listunspent(const Array& params, bool fHelp)
                 continue;
         }
 
-        mpq nValue = GetPresentValue(*out.tx, out.tx->vout[out.i], nBestHeight, false);
+        mpq nValue = GetPresentValue(*out.tx, out.tx->vout[out.i], nBestHeight, true);
         const CScript& pk = out.tx->vout[out.i].scriptPubKey;
         Object entry;
         entry.push_back(Pair("txid", out.tx->GetHash().GetHex()));

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -221,7 +221,7 @@ Value listunspent(const Array& params, bool fHelp)
                 continue;
         }
 
-        mpq nValue = GetPresentValue(*out.tx, out.tx->vout[out.i], nBestHeight);
+        mpq nValue = GetPresentValue(*out.tx, out.tx->vout[out.i], nBestHeight, false);
         const CScript& pk = out.tx->vout[out.i].scriptPubKey;
         Object entry;
         entry.push_back(Pair("txid", out.tx->GetHash().GetHex()));

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -388,7 +388,7 @@ mpq GetReceivedValue(const CWalletTx &wtx, const CTxOut &txout)
 {
     CBlockIndex *pBlockIndex;
     int nBlockDepth = wtx.GetDepthInMainChain(pBlockIndex);
-    return GetPresentValue(wtx, txout, nBestHeight + 1 - nBlockDepth - wtx.nRefHeight);
+    return GetPresentValue(wtx, txout, nBestHeight + 1 - nBlockDepth - wtx.nRefHeight, false);
 }
 
 Value getreceivedbyaddress(const Array& params, bool fHelp)
@@ -1139,7 +1139,7 @@ Value listaccounts(const Array& params, bool fHelp)
     list<CAccountingEntry> acentries;
     CWalletDB(pwalletMain->strWalletFile).ListAccountCreditDebit("*", acentries);
     BOOST_FOREACH(const CAccountingEntry& entry, acentries)
-        mapAccountBalances[entry.strAccount] += GetTimeAdjustedValue(entry.nCreditDebit, nHeight - entry.nRefHeight);
+        mapAccountBalances[entry.strAccount] += GetTimeAdjustedValue_mpfr(entry.nCreditDebit, nHeight - entry.nRefHeight);
 
     Object ret;
     BOOST_FOREACH(const PAIRTYPE(string, mpq)& accountBalance, mapAccountBalances) {

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -388,7 +388,7 @@ mpq GetReceivedValue(const CWalletTx &wtx, const CTxOut &txout)
 {
     CBlockIndex *pBlockIndex;
     int nBlockDepth = wtx.GetDepthInMainChain(pBlockIndex);
-    return GetPresentValue(wtx, txout, nBestHeight + 1 - nBlockDepth - wtx.nRefHeight, false);
+    return GetPresentValue(wtx, txout, nBestHeight + 1 - nBlockDepth - wtx.nRefHeight, true);
 }
 
 Value getreceivedbyaddress(const Array& params, bool fHelp)
@@ -1139,7 +1139,7 @@ Value listaccounts(const Array& params, bool fHelp)
     list<CAccountingEntry> acentries;
     CWalletDB(pwalletMain->strWalletFile).ListAccountCreditDebit("*", acentries);
     BOOST_FOREACH(const CAccountingEntry& entry, acentries)
-        mapAccountBalances[entry.strAccount] += GetTimeAdjustedValue_mpfr(entry.nCreditDebit, nHeight - entry.nRefHeight);
+        mapAccountBalances[entry.strAccount] += GetTimeAdjustedValue_apu(entry.nCreditDebit, nHeight - entry.nRefHeight);
 
     Object ret;
     BOOST_FOREACH(const PAIRTYPE(string, mpq)& accountBalance, mapAccountBalances) {

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -68,7 +68,7 @@ public:
 class CWallet : public CCryptoKeyStore
 {
 private:
-    bool SelectCoins(const mpq& nTargetValue, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, mpq& nValueRet, int nRefHeight=-1, bool fTruncateInputs=true, bool fUseAPU=false) const;
+    bool SelectCoins(const mpq& nTargetValue, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, mpq& nValueRet, int nRefHeight=-1, bool fTruncateInputs=true, bool fUseAPU=true) const;
 
     CWalletDB *pwalletdbEncryption;
 
@@ -125,7 +125,7 @@ public:
     bool CanSupportFeature(enum WalletFeature wf) { return nWalletMaxVersion >= wf; }
 
     void AvailableCoins(std::vector<COutput>& vCoins, int nRefHeight=-1, bool fOnlyConfirmed=true) const;
-    bool SelectCoinsMinConf(const mpq& nTargetValue, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, mpq& nValueRet, int nRefHeight=-1, bool fTruncateInputs=true, bool fUseAPU=false) const;
+    bool SelectCoinsMinConf(const mpq& nTargetValue, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, mpq& nValueRet, int nRefHeight=-1, bool fTruncateInputs=true, bool fUseAPU=true) const;
     bool IsLockedCoin(uint256 hash, unsigned int n) const;
     void LockCoin(COutPoint& output);
     void UnlockCoin(COutPoint& output);
@@ -207,7 +207,7 @@ public:
     }
     mpq GetCredit(const CTransaction& tx, const CTxOut& txout, int nBlockHeight) const
     {
-        mpq nCredit = GetPresentValue(tx, txout, nBlockHeight, false);
+        mpq nCredit = GetPresentValue(tx, txout, nBlockHeight, true);
         if (!MoneyRange(nCredit))
             throw std::runtime_error("CWallet::GetCredit() : value out of range");
         return (IsMine(txout) ? nCredit : 0);
@@ -215,7 +215,7 @@ public:
     bool IsChange(const CTxOut& txout) const;
     mpq GetChange(const CTransaction& tx, const CTxOut& txout, int nBlockHeight) const
     {
-        mpq nChange = GetPresentValue(tx, txout, nBlockHeight, false);
+        mpq nChange = GetPresentValue(tx, txout, nBlockHeight, true);
         if (!MoneyRange(nChange))
             throw std::runtime_error("CWallet::GetChange() : value out of range");
         return (IsChange(txout) ? nChange : 0);

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -68,7 +68,7 @@ public:
 class CWallet : public CCryptoKeyStore
 {
 private:
-    bool SelectCoins(const mpq& nTargetValue, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, mpq& nValueRet, int nRefHeight=-1, bool fTruncateInputs=true) const;
+    bool SelectCoins(const mpq& nTargetValue, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, mpq& nValueRet, int nRefHeight=-1, bool fTruncateInputs=true, bool fUseAPU=false) const;
 
     CWalletDB *pwalletdbEncryption;
 
@@ -125,7 +125,7 @@ public:
     bool CanSupportFeature(enum WalletFeature wf) { return nWalletMaxVersion >= wf; }
 
     void AvailableCoins(std::vector<COutput>& vCoins, int nRefHeight=-1, bool fOnlyConfirmed=true) const;
-    bool SelectCoinsMinConf(const mpq& nTargetValue, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, mpq& nValueRet, int nRefHeight=-1, bool fTruncateInputs=true) const;
+    bool SelectCoinsMinConf(const mpq& nTargetValue, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, mpq& nValueRet, int nRefHeight=-1, bool fTruncateInputs=true, bool fUseAPU=false) const;
     bool IsLockedCoin(uint256 hash, unsigned int n) const;
     void LockCoin(COutPoint& output);
     void UnlockCoin(COutPoint& output);
@@ -207,7 +207,7 @@ public:
     }
     mpq GetCredit(const CTransaction& tx, const CTxOut& txout, int nBlockHeight) const
     {
-        mpq nCredit = GetPresentValue(tx, txout, nBlockHeight);
+        mpq nCredit = GetPresentValue(tx, txout, nBlockHeight, false);
         if (!MoneyRange(nCredit))
             throw std::runtime_error("CWallet::GetCredit() : value out of range");
         return (IsMine(txout) ? nCredit : 0);
@@ -215,7 +215,7 @@ public:
     bool IsChange(const CTxOut& txout) const;
     mpq GetChange(const CTransaction& tx, const CTxOut& txout, int nBlockHeight) const
     {
-        mpq nChange = GetPresentValue(tx, txout, nBlockHeight);
+        mpq nChange = GetPresentValue(tx, txout, nBlockHeight, false);
         if (!MoneyRange(nChange))
             throw std::runtime_error("CWallet::GetChange() : value out of range");
         return (IsChange(txout) ? nChange : 0);

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -60,7 +60,7 @@ mpq CWalletDB::GetAccountCreditDebit(const string& strAccount, int nBlockHeight)
 
     mpq nCreditDebit = 0;
     BOOST_FOREACH (const CAccountingEntry& entry, entries)
-        nCreditDebit += GetTimeAdjustedValue(entry.nCreditDebit, nBlockHeight-entry.nRefHeight);
+        nCreditDebit += GetTimeAdjustedValue_mpfr(entry.nCreditDebit, nBlockHeight-entry.nRefHeight);
 
     return nCreditDebit;
 }

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -60,7 +60,7 @@ mpq CWalletDB::GetAccountCreditDebit(const string& strAccount, int nBlockHeight)
 
     mpq nCreditDebit = 0;
     BOOST_FOREACH (const CAccountingEntry& entry, entries)
-        nCreditDebit += GetTimeAdjustedValue_mpfr(entry.nCreditDebit, nBlockHeight-entry.nRefHeight);
+        nCreditDebit += GetTimeAdjustedValue_apu(entry.nCreditDebit, nBlockHeight-entry.nRefHeight);
 
     return nCreditDebit;
 }


### PR DESCRIPTION
Switch to an integer-math-only method for performing demurrage calculations. Note that due to truncation of the intermediate multiplication terms it is possible for this method to disagree with the results of the MPFR calculation by as much as 1 kria, even after the latter is truncated. It boasts a 10x improvement in speed, however, and allows for the GMP and MPFR libraries to be fully removed as dependencies from freicoin-supporting software. This is a big step forward in minimizing code differences between freicoin and the bitcoin reference software.

It is observed in practice that if more precision were used in the integer exponentiation then the difference between the integer math and MPFR results can be reduced to zero in nearly all cases. But "nearly all" is not "provably all", and in fact it is quite difficult to prove that there is no edge case which wouldn't result in a truncation, which could be purposefully exploited to partition the network. So rather than target near, but not absolute compatibility, we instead simplify the calculation as much as possible while staying within a no-more-than-1 kria error bound. The error, if it exists, is always in the downward direction, meaning less input (by a few kria), which is a soft-fork change for future transactions.

Rollout of the soft fork is done via a BIP8-like activation period of the new truncation rules. This is an old-style supermajority rollout with BIP8/BIP9-like version bits and BIP8-like activation-on-timeout semantics. It's not strictly compatible with those BIPs though, as we didn't want to back port all the necessary state management code. But miners using BIP8/BIP9 compatible version bits software should work with this rollout by configuring their devices to signal bit #28 (the highest-order BIP8/BIP9 bit).

Regardless of the outcome of the miner signaling period, the new rules activate on block 229376.